### PR TITLE
fix: https.get would make a http request

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ for (var key in http) {
 
 https.request = function (params, cb) {
     if (!params) params = {};
-    params.scheme = 'https';
+    params.protocol = 'https:';
     return http.request.call(this, params, cb);
+}
+
+https.get = function (params, cb) {
+    if !(params) params = {}
+    params.protocol = 'https:';
+    return http.get.call(this, params, cb);
 }


### PR DESCRIPTION
The `get` function wasn't overwritten, so that a http request was send.