### PR TITLE
set protocol to https:

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ for (var key in http) {
 https.request = function (params, cb) {
     if (!params) params = {};
     params.scheme = 'https';
+    params.protocol = 'https:';
     return http.request.call(this, params, cb);
 }


### PR DESCRIPTION
the new stream-http only accepts the protocol option ([which I think is correct](https://iojs.org/api/http.html#http_http_request_options_callback)) - http-browserify used to have a workaround for dealing with scheme:

https://github.com/substack/http-browserify/commit/cf4f5a82292bb50fc94b09d335c6d6cefa4c5264

noticed this because with the new browserify, hyperquest can't make requests to secure origins from insecure ones.

/cc @jhiesey