### PR TITLE
jspm Node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,12 @@
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
+  "jspm": {
+    "map": {
+      "./index.js": {
+        "node": "@node/https"
+      }
+    }
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
As with https://github.com/feross/buffer/pull/84, this provides the jspm configuration such that this package can be installed through jspm and provide `https` both client and server in the coming jspm 0.17 release.

Including it here removes the need to have custom overrides maintaining this information.

No pressure to land this and just let me know if you have any questions. Thanks for considering.